### PR TITLE
fix typos using codespell

### DIFF
--- a/config/pipeline_setup.py
+++ b/config/pipeline_setup.py
@@ -20,7 +20,7 @@ os.mkdir(package_dir)
 os.mkdir(artifact_dir)
 
 
-# Download test EEG data (curently using S004R01 from the BCI2000 dataset)
+# Download test EEG data (currently using S004R01 from the BCI2000 dataset)
 
 subject = 'S004'
 run = 'R01'

--- a/config/settings.m
+++ b/config/settings.m
@@ -18,7 +18,7 @@ montage_dir = [eeglab_path sep 'plugins' sep 'dipfit' sep 'standard_BESA'];
 montage_path = [montage_dir sep montage_name];
 
 
-% Intitialize PREP parameters
+% Initialize PREP parameters
 
 powerline_hz = 60;
 


### PR DESCRIPTION
I was going through pyprep with codespell to purge some typos, and found there were some in the git submodule we use (this repo).